### PR TITLE
New feature - Alpha Masking 

### DIFF
--- a/Trainer.py
+++ b/Trainer.py
@@ -4,7 +4,7 @@ import torch
 
 import Framework
 from Datasets.Base import BaseDataset
-from Datasets.utils import BasicPointCloud, apply_background_color
+from Datasets.utils import BasicPointCloud, apply_background_color, get_supervision_alpha
 from Logging import Logger
 from Methods.Base.GuiTrainer import GuiTrainer
 from Methods.Base.utils import pre_training_callback, training_callback, post_training_callback
@@ -178,7 +178,6 @@ class FasterGSTrainer(GuiTrainer):
         self.model.gaussians.update_learning_rate(iteration + 1)
         # get random view
         view = self.train_sampler.get(dataset=dataset)['view']
-        # render
         bg_color = torch.rand_like(view.camera.background_color) if self.USE_RANDOM_BACKGROUND_COLOR else view.camera.background_color
         image = self.renderer.render_image_training(
             view=view,
@@ -188,8 +187,8 @@ class FasterGSTrainer(GuiTrainer):
         # calculate loss
         # compose gt with background color if needed  # FIXME: integrate into data model
         rgb_gt = view.rgb
-        if (alpha_gt := view.alpha) is not None:
-            rgb_gt = apply_background_color(rgb_gt, alpha_gt, bg_color)
+        if (supervision_alpha := get_supervision_alpha(view)) is not None:
+            rgb_gt = apply_background_color(rgb_gt, supervision_alpha, bg_color)
         loss = self.loss(image, rgb_gt)
         # backward
         loss.backward()
@@ -244,8 +243,8 @@ class FasterGSTrainer(GuiTrainer):
                     # calculate loss
                     # compose gt with background color if needed  # FIXME: integrate into data model
                     rgb_gt = view.rgb
-                    if (alpha_gt := view.alpha) is not None:
-                        rgb_gt = apply_background_color(rgb_gt, alpha_gt, view.camera.background_color)
+                    if (supervision_alpha := get_supervision_alpha(view)) is not None:
+                        rgb_gt = apply_background_color(rgb_gt, supervision_alpha, view.camera.background_color)
                     loss = self.loss(image, rgb_gt)
                     # backward
                     loss.backward()

--- a/utils.py
+++ b/utils.py
@@ -43,7 +43,12 @@ def carve(points: torch.Tensor, dataset: BaseDataset, in_all_frustums: bool, enf
         in_frustum_any |= in_frustum
         if in_all_frustums:
             in_frustum_all &= in_frustum
-        if enforce_alpha and in_frustum.any() and (alpha_gt := view.alpha) is not None:
+        if enforce_alpha and in_frustum.any():
+            alpha_gt = view.alpha
+            if alpha_gt is None:
+                alpha_gt = view.segmentation
+            if alpha_gt is None:
+                continue
             alpha_gt = torch.nn.functional.conv2d(alpha_gt[None], dilation_kernel, padding=1)[0] > 0
             xy_screen = torch.floor(xy_screen[in_frustum]).long()
             valid_alpha = alpha_gt[0, xy_screen[:, 1], xy_screen[:, 0]] > 0


### PR DESCRIPTION
TL:DR: Adapting the loss function to work with random background change + extra configuration fields.
Masks are binary and should match the input images in resolution.


* Add RANDOM_BACKGROUND_IF_ALPHA_OR_MASK, EXTERNAL_MASKS_PATH, and NORMALIZE_LOSS_BY_MASK_AREA; composite supervision alpha (dataset alpha times optional external mask) against the same bg_color as the rasterizer. 

* Preload external masks via setup_external_masks. Carving with enforce_alpha falls back to view.segmentation when alpha is absent.

This PR was assisted by cursor (Composer + Opus).

